### PR TITLE
feat: add manual tagging (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ your second brain, a zero-friction CLI for capturing and retrieving thoughts.
 
 Thoughts are stored as plain markdown files in `~/.ikkinchi/memories/`.
 
-Search is hybrid: semantic via Ollama embeddings + fuzzy matching. No folders, no tags, no cloud.
+Search is hybrid: semantic via Ollama embeddings + fuzzy matching. No folders, no cloud.
 
 ## Install
 
@@ -45,6 +45,7 @@ ikkinchi init
 
 ```bash
 ikkinchi add "what do fish think about all day?"
+ikkinchi add "learned how the borrow checker works" --tag rust --tag til
 ikkinchi add "There is a @swc/react-compiler package but no documentation"
 ```
 
@@ -64,10 +65,19 @@ At search time, Rig embeds your query using the same Ollama model and computes c
 
 ```bash
 ikkinchi tui               # open interactive terminal UI
-ikkinchi list              # newest first
+ikkinchi list              # newest first, with tags shown
+ikkinchi list --tag rust   # filter by tag
 ikkinchi edit <id> <text>  # update a thought (re-embeds automatically)
 ikkinchi delete <id>       # remove a thought
-ikkinchi stats             # memory count, date range, vector count
+ikkinchi stats             # memory count, date range, vector count, tag count
+```
+
+**Manage tags:**
+
+```bash
+ikkinchi tags                          # list all tags with counts
+ikkinchi tag add <id> rust til         # add tags to a memory
+ikkinchi tag remove <id> til           # remove a tag
 ```
 
 **Rebuild the vector index:**
@@ -109,17 +119,20 @@ You can read, edit, or back up your memories directly — they're just markdown.
 ## Commands
 
 ```
-ikkinchi init              Set up ~/.ikkinchi/, create config
-ikkinchi add <text>        Capture a thought
-ikkinchi search <query>    Semantic + fuzzy hybrid search
-ikkinchi tui               Launch interactive terminal UI
-ikkinchi list [--count N]  Browse recent memories
-ikkinchi edit <id> <text>  Update a memory
-ikkinchi delete <id>...    Delete one or more memories
-ikkinchi import <path>     Import .md/.txt files
+ikkinchi init                          Set up ~/.ikkinchi/, create config
+ikkinchi add <text> [--tag <tag>]...   Capture a thought, optionally tagged
+ikkinchi search <query> [--tag <tag>]  Semantic + fuzzy hybrid search
+ikkinchi tui                           Launch interactive terminal UI
+ikkinchi list [--count N] [--tag <tag>] Browse recent memories
+ikkinchi edit <id> <text>              Update a memory
+ikkinchi delete <id>...                Delete one or more memories
+ikkinchi tags                          List all tags with counts
+ikkinchi tag add <id> <tag>...         Add tags to a memory
+ikkinchi tag remove <id> <tag>...      Remove tags from a memory
+ikkinchi import <path>                 Import .md/.txt files
 ikkinchi export [--format json|markdown]  Export all memories
-ikkinchi reindex           Rebuild vector index from markdown files
-ikkinchi stats             Show memory and vector counts
+ikkinchi reindex                       Rebuild vector index from markdown files
+ikkinchi stats                         Show memory, vector, and tag counts
 ```
 
 Run `ikkinchi --help` for details on any command.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 pub async fn run(text: &str) -> Result<()> {
     let config = Config::load()?;
     let store = Store::from_config();
-    let id = store.append(text)?;
+    let id = store.append(text, &[])?;
     println!("Captured: {}", id);
 
     // Embed and store vector — non-fatal if Ollama is unavailable

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -4,10 +4,10 @@ use crate::store::Store;
 use crate::vectordb::VectorDb;
 use anyhow::Result;
 
-pub async fn run(text: &str) -> Result<()> {
+pub async fn run(text: &str, tags: &[String]) -> Result<()> {
     let config = Config::load()?;
     let store = Store::from_config();
-    let id = store.append(text, &[])?;
+    let id = store.append(text, tags)?;
     println!("Captured: {}", id);
 
     // Embed and store vector — non-fatal if Ollama is unavailable

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -19,6 +19,7 @@ pub fn format_memories(memories: &[Memory], format: Option<&str>) -> Result<Stri
                         "date": m.date,
                         "time": m.time,
                         "text": m.text,
+                        "tags": m.tags,
                     })
                 })
                 .collect();
@@ -97,5 +98,22 @@ mod tests {
     fn test_export_unknown_format_errors() {
         let result = format_memories(&[], Some("csv"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_export_json_includes_tags() {
+        let mut m = make_memory("2026-03-10", "14:32:05", "tagged");
+        m.tags = vec!["rust".to_string(), "til".to_string()];
+        let result = format_memories(&[m], Some("json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed[0]["tags"], serde_json::json!(["rust", "til"]));
+    }
+
+    #[test]
+    fn test_export_json_empty_tags_is_array() {
+        let m = make_memory("2026-03-10", "14:32:05", "no tags");
+        let result = format_memories(&[m], Some("json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed[0]["tags"], serde_json::json!([]));
     }
 }

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -19,7 +19,7 @@ async fn import_one(
 ) -> Result<()> {
     let content = std::fs::read_to_string(path)?;
     for chunk in chunk_text(&content) {
-        let id = store.append(&chunk)?;
+        let id = store.append(&chunk, &[])?;
         println!("Imported: {}", id);
 
         if let Some((client, db)) = embed {

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,8 +1,21 @@
 use crate::config::Config;
-use crate::store::Store;
+use crate::store::{Memory, Store};
 use anyhow::Result;
 
-pub async fn run(count: Option<usize>) -> Result<()> {
+pub fn format_tag_block(m: &Memory) -> String {
+    if m.tags.is_empty() {
+        return String::new();
+    }
+    let tags = m.tags.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(", ");
+    format!("[{}] ", tags)
+}
+
+pub fn filter_by_tag<'a>(memories: &'a [Memory], tag: &str) -> Vec<&'a Memory> {
+    let normalized = tag.to_lowercase();
+    memories.iter().filter(|m| m.tags.contains(&normalized)).collect()
+}
+
+pub async fn run(count: Option<usize>, tag: Option<String>) -> Result<()> {
     let config = Config::load()?;
     let limit = count.unwrap_or(config.display.list_count);
     let store = Store::from_config();
@@ -13,8 +26,81 @@ pub async fn run(count: Option<usize>) -> Result<()> {
         return Ok(());
     }
 
-    for (i, m) in memories.iter().enumerate() {
-        println!("{:>3}  {}  {}", i + 1, m.id, m.text);
+    match &tag {
+        None => {
+            for (i, m) in memories.iter().enumerate() {
+                println!("{:>3}  {}  {}{}", i + 1, m.id, format_tag_block(m), m.text);
+            }
+        }
+        Some(t) => {
+            let filtered = filter_by_tag(&memories, t);
+            if filtered.is_empty() {
+                println!("No memories with tag: #{}", t.to_lowercase());
+            } else {
+                for (i, m) in filtered.iter().enumerate() {
+                    println!("{:>3}  {}  {}{}", i + 1, m.id, format_tag_block(m), m.text);
+                }
+            }
+        }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Memory;
+
+    fn make_memory(date: &str, time: &str, text: &str, tags: Vec<&str>) -> Memory {
+        let mut m = Memory::new(date, time, text);
+        m.tags = tags.into_iter().map(|s| s.to_string()).collect();
+        m
+    }
+
+    #[test]
+    fn test_format_tag_block_empty() {
+        let m = make_memory("2026-03-11", "10:00:00", "text", vec![]);
+        assert_eq!(format_tag_block(&m), "");
+    }
+
+    #[test]
+    fn test_format_tag_block_single() {
+        let m = make_memory("2026-03-11", "10:00:00", "text", vec!["rust"]);
+        assert_eq!(format_tag_block(&m), "[#rust] ");
+    }
+
+    #[test]
+    fn test_format_tag_block_multiple() {
+        let m = make_memory("2026-03-11", "10:00:00", "text", vec!["rust", "til"]);
+        assert_eq!(format_tag_block(&m), "[#rust, #til] ");
+    }
+
+    #[test]
+    fn test_filter_by_tag_returns_matches() {
+        let memories = vec![
+            make_memory("2026-03-11", "10:00:00", "first", vec!["rust"]),
+            make_memory("2026-03-11", "11:00:00", "second", vec!["til"]),
+        ];
+        let result = filter_by_tag(&memories, "rust");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].text, "first");
+    }
+
+    #[test]
+    fn test_filter_by_tag_case_insensitive() {
+        let memories = vec![
+            make_memory("2026-03-11", "10:00:00", "first", vec!["rust"]),
+        ];
+        let result = filter_by_tag(&memories, "RUST");
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_filter_by_tag_no_match_returns_empty() {
+        let memories = vec![
+            make_memory("2026-03-11", "10:00:00", "first", vec!["rust"]),
+        ];
+        let result = filter_by_tag(&memories, "haskell");
+        assert!(result.is_empty());
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,8 @@ pub mod list;
 pub mod reindex;
 pub mod search;
 pub mod stats;
+pub mod tag;
+pub mod tags;
 
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -83,6 +85,15 @@ pub enum Commands {
         format: Option<String>,
     },
 
+    /// Add or remove tags on a memory
+    Tag {
+        #[command(subcommand)]
+        action: TagAction,
+    },
+
+    /// List all tags with counts
+    Tags,
+
     /// Show brain statistics
     Stats,
 
@@ -91,4 +102,22 @@ pub enum Commands {
 
     /// Launch interactive TUI
     Tui,
+}
+
+#[derive(Subcommand)]
+pub enum TagAction {
+    /// Add tags to a memory
+    Add {
+        /// Memory ID (e.g. 2026-03-11/14:32:05)
+        id: String,
+        /// Tag(s) to add
+        tags: Vec<String>,
+    },
+    /// Remove tags from a memory
+    Remove {
+        /// Memory ID (e.g. 2026-03-11/14:32:05)
+        id: String,
+        /// Tag(s) to remove
+        tags: Vec<String>,
+    },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,6 +32,9 @@ pub enum Commands {
     Add {
         /// The thought to capture
         text: String,
+        /// Tag(s) to attach (repeatable: --tag rust --tag til)
+        #[arg(short, long)]
+        tag: Vec<String>,
     },
 
     /// Semantic + fuzzy hybrid search
@@ -45,6 +48,9 @@ pub enum Commands {
         /// Number of memories to show (default: 20)
         #[arg(short, long)]
         count: Option<usize>,
+        /// Filter by tag
+        #[arg(short, long)]
+        tag: Option<String>,
     },
 
     /// Replace a memory's content

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -41,6 +41,9 @@ pub enum Commands {
     Search {
         /// Search query
         query: String,
+        /// Filter results by tag
+        #[arg(short, long)]
+        tag: Option<String>,
     },
 
     /// List memories, newest first

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -100,7 +100,7 @@ async fn semantic_search(
 }
 
 
-pub async fn run(query: &str) -> Result<()> {
+pub async fn run(query: &str, tag: Option<String>) -> Result<()> {
     let config = Config::load()?;
     let limit = config.display.list_count;
     let store = Store::from_config();
@@ -154,21 +154,36 @@ pub async fn run(query: &str) -> Result<()> {
     let ranked = hybrid_rank(&semantic_results, &fuzzy_results, limit);
 
     if ranked.is_empty() {
-        println!("No memories found for: {}", query);
+        match &tag {
+            None => println!("No memories found for: {}", query),
+            Some(t) => println!("No results for: {} (tag: #{})", query, t.to_lowercase()),
+        }
         return Ok(());
     }
 
-    // 4. Resolve IDs back to Memory structs
+    // 4. Resolve IDs back to Memory structs and apply optional tag filter
     let mut display_index = 1;
+    let tag_normalized = tag.as_deref().map(|t| t.to_lowercase());
     for (id, _score) in &ranked {
         match store.get(id)? {
             Some(m) => {
+                if let Some(ref t) = tag_normalized {
+                    if !m.tags.contains(t) {
+                        continue;
+                    }
+                }
                 println!("{:>3}  {}  {}", display_index, m.id, m.text);
                 display_index += 1;
             }
             None => {
                 eprintln!("Warning: memory '{}' found in vector index but not in store (run `ikkinchi reindex`)", id);
             }
+        }
+    }
+
+    if display_index == 1 {
+        if let Some(t) = &tag {
+            println!("No results for: {} (tag: #{})", query, t.to_lowercase());
         }
     }
 

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -8,6 +8,7 @@ pub struct Stats {
     pub days: usize,
     pub oldest: String,
     pub newest: String,
+    pub distinct_tags: usize,
 }
 
 pub fn compute_stats(store: &Store) -> Result<Option<Stats>> {
@@ -18,11 +19,14 @@ pub fn compute_stats(store: &Store) -> Result<Option<Stats>> {
     let days: HashSet<&str> = all.iter().map(|m| m.date.as_str()).collect();
     let oldest = all.iter().map(|m| m.date.as_str()).min().unwrap().to_string();
     let newest = all.iter().map(|m| m.date.as_str()).max().unwrap().to_string();
+    let distinct_tags: std::collections::HashSet<&str> =
+        all.iter().flat_map(|m| m.tags.iter().map(|t| t.as_str())).collect();
     Ok(Some(Stats {
         total: all.len(),
         days: days.len(),
         oldest,
         newest,
+        distinct_tags: distinct_tags.len(),
     }))
 }
 
@@ -43,6 +47,7 @@ pub async fn run() -> Result<()> {
                 Err(_) => "unavailable".to_string(),
             };
             println!("Vectors:  {:>10}", vector_count);
+            println!("Tags:     {:>10}", s.distinct_tags);
         }
     }
     Ok(())
@@ -100,5 +105,17 @@ mod tests {
         assert_eq!(stats.days, 2);
         assert_eq!(stats.oldest, "2026-03-09");
         assert_eq!(stats.newest, "2026-03-10");
+    }
+
+    #[test]
+    fn test_stats_distinct_tag_count() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        std::fs::write(
+            store.memories_dir.join("2026-03-10.md"),
+            "## 10:00:00\n#rust, #til\n\nhello\n\n## 11:00:00\n#rust\n\nworld\n\n",
+        ).unwrap();
+        let stats = compute_stats(&store).unwrap().unwrap();
+        assert_eq!(stats.distinct_tags, 2); // rust, til
     }
 }

--- a/src/cli/tag.rs
+++ b/src/cli/tag.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 pub async fn run_add(id: &str, tags: &[String]) -> Result<()> {
     let store = Store::from_config();
     store.add_tags(id, tags)?;
-    let m = store.get(id)?.ok_or_else(|| anyhow::anyhow!("Memory not found: {}", id))?;
+    let m = store.get(id)?.expect("memory must exist after add_tags succeeded");
     let tag_display = m.tags.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(", ");
     println!("Tagged {}: {}", id, tag_display);
     Ok(())
@@ -13,7 +13,7 @@ pub async fn run_add(id: &str, tags: &[String]) -> Result<()> {
 pub async fn run_remove(id: &str, tags: &[String]) -> Result<()> {
     let store = Store::from_config();
     store.remove_tags(id, tags)?;
-    let m = store.get(id)?.ok_or_else(|| anyhow::anyhow!("Memory not found: {}", id))?;
+    let m = store.get(id)?.expect("memory must exist after remove_tags succeeded");
     if m.tags.is_empty() {
         println!("Tags cleared {}", id);
     } else {
@@ -21,4 +21,29 @@ pub async fn run_remove(id: &str, tags: &[String]) -> Result<()> {
         println!("Tags updated {}: {}", id, tag_display);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    fn tag_display(tags: &[String]) -> String {
+        tags.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(", ")
+    }
+
+    #[test]
+    fn test_tag_display_single() {
+        let tags = vec!["rust".to_string()];
+        assert_eq!(tag_display(&tags), "#rust");
+    }
+
+    #[test]
+    fn test_tag_display_multiple() {
+        let tags = vec!["rust".to_string(), "til".to_string()];
+        assert_eq!(tag_display(&tags), "#rust, #til");
+    }
+
+    #[test]
+    fn test_tag_display_empty() {
+        let tags: Vec<String> = vec![];
+        assert_eq!(tag_display(&tags), "");
+    }
 }

--- a/src/cli/tag.rs
+++ b/src/cli/tag.rs
@@ -1,0 +1,24 @@
+use crate::store::Store;
+use anyhow::Result;
+
+pub async fn run_add(id: &str, tags: &[String]) -> Result<()> {
+    let store = Store::from_config();
+    store.add_tags(id, tags)?;
+    let m = store.get(id)?.ok_or_else(|| anyhow::anyhow!("Memory not found: {}", id))?;
+    let tag_display = m.tags.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(", ");
+    println!("Tagged {}: {}", id, tag_display);
+    Ok(())
+}
+
+pub async fn run_remove(id: &str, tags: &[String]) -> Result<()> {
+    let store = Store::from_config();
+    store.remove_tags(id, tags)?;
+    let m = store.get(id)?.ok_or_else(|| anyhow::anyhow!("Memory not found: {}", id))?;
+    if m.tags.is_empty() {
+        println!("Tags cleared {}", id);
+    } else {
+        let tag_display = m.tags.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(", ");
+        println!("Tags updated {}: {}", id, tag_display);
+    }
+    Ok(())
+}

--- a/src/cli/tags.rs
+++ b/src/cli/tags.rs
@@ -1,0 +1,77 @@
+use crate::store::{Memory, Store};
+use anyhow::Result;
+use std::collections::HashMap;
+
+pub fn count_tags(memories: &[Memory]) -> Vec<(String, usize)> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for m in memories {
+        for tag in &m.tags {
+            *counts.entry(tag.clone()).or_insert(0) += 1;
+        }
+    }
+    let mut sorted: Vec<(String, usize)> = counts.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    sorted
+}
+
+pub async fn run() -> Result<()> {
+    let store = Store::from_config();
+    let memories = store.list(usize::MAX)?;
+    let counts = count_tags(&memories);
+    if counts.is_empty() {
+        println!("No tags yet.");
+        return Ok(());
+    }
+    let max_tag_len = counts.iter().map(|(t, _)| t.len() + 1).max().unwrap_or(0);
+    for (tag, count) in &counts {
+        let display = format!("#{}", tag);
+        println!("  {:<width$}  {}", display, count, width = max_tag_len);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Memory;
+
+    fn make_memory(tags: Vec<&str>) -> Memory {
+        let mut m = Memory::new("2026-03-11", "10:00:00", "text");
+        m.tags = tags.into_iter().map(|s| s.to_string()).collect();
+        m
+    }
+
+    #[test]
+    fn test_count_tags_empty() {
+        let result = count_tags(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_count_tags_single() {
+        let memories = vec![make_memory(vec!["rust"])];
+        let result = count_tags(&memories);
+        assert_eq!(result, vec![("rust".to_string(), 1)]);
+    }
+
+    #[test]
+    fn test_count_tags_multiple_memories() {
+        let memories = vec![
+            make_memory(vec!["rust", "til"]),
+            make_memory(vec!["rust"]),
+        ];
+        let result = count_tags(&memories);
+        let rust = result.iter().find(|(t, _)| t == "rust").unwrap();
+        let til = result.iter().find(|(t, _)| t == "til").unwrap();
+        assert_eq!(rust.1, 2);
+        assert_eq!(til.1, 1);
+        assert_eq!(result[0].0, "rust");
+    }
+
+    #[test]
+    fn test_count_tags_no_tags_returns_empty() {
+        let memories = vec![make_memory(vec![])];
+        let result = count_tags(&memories);
+        assert!(result.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,9 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Init => ikkinchi::cli::init::run().await?,
-        Commands::Add { text } => ikkinchi::cli::add::run(&text).await?,
+        Commands::Add { text, tag } => ikkinchi::cli::add::run(&text, &tag).await?,
         Commands::Search { query } => ikkinchi::cli::search::run(&query).await?,
-        Commands::List { count } => ikkinchi::cli::list::run(count).await?,
+        Commands::List { count, tag } => ikkinchi::cli::list::run(count, tag).await?,
         Commands::Edit { id, text } => ikkinchi::cli::edit::run(&id, &text).await?,
         Commands::Delete { ids } => ikkinchi::cli::delete::run(&ids).await?,
         Commands::Import { path } => ikkinchi::cli::import::run(&path).await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use ikkinchi::cli::{Cli, Commands};
+use ikkinchi::cli::{Cli, Commands, TagAction};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -17,6 +17,11 @@ async fn main() -> Result<()> {
         Commands::Export { format } => {
             ikkinchi::cli::export::run(format.as_deref()).await?
         }
+        Commands::Tag { action } => match action {
+            TagAction::Add { id, tags } => ikkinchi::cli::tag::run_add(&id, &tags).await?,
+            TagAction::Remove { id, tags } => ikkinchi::cli::tag::run_remove(&id, &tags).await?,
+        },
+        Commands::Tags => ikkinchi::cli::tags::run().await?,
         Commands::Stats => ikkinchi::cli::stats::run().await?,
         Commands::Reindex => ikkinchi::cli::reindex::run().await?,
         Commands::Tui => ikkinchi::tui::run().await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::Init => ikkinchi::cli::init::run().await?,
         Commands::Add { text, tag } => ikkinchi::cli::add::run(&text, &tag).await?,
-        Commands::Search { query } => ikkinchi::cli::search::run(&query).await?,
+        Commands::Search { query, tag } => ikkinchi::cli::search::run(&query, tag).await?,
         Commands::List { count, tag } => ikkinchi::cli::list::run(count, tag).await?,
         Commands::Edit { id, text } => ikkinchi::cli::edit::run(&id, &text).await?,
         Commands::Delete { ids } => ikkinchi::cli::delete::run(&ids).await?,

--- a/src/store.rs
+++ b/src/store.rs
@@ -184,8 +184,8 @@ fn normalize_tag(raw: &str) -> Option<String> {
     let normalized: String = raw
         .chars()
         .filter(|c| c.is_alphanumeric() || *c == ' ' || *c == '-')
-        .collect::<String>()
-        .to_lowercase();
+        .flat_map(|c| c.to_lowercase())
+        .collect();
     let tag = normalized.trim().to_string();
     if tag.is_empty() { None } else { Some(tag) }
 }
@@ -665,5 +665,27 @@ mod tests {
         let memory = store.get(&id).unwrap().unwrap();
         assert!(memory.tags.is_empty());
         assert_eq!(memory.text, "plain thought");
+    }
+
+    #[test]
+    fn test_write_file_round_trips_tags() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        let mut m = Memory::new("2026-03-11", "14:32:05", "borrow checker");
+        m.tags = vec!["rust".to_string(), "til".to_string()];
+        write_file(&file_path, &[m]).unwrap();
+        let memory = store.get("2026-03-11/14:32:05").unwrap().unwrap();
+        assert_eq!(memory.tags, vec!["rust", "til"]);
+        assert_eq!(memory.text, "borrow checker");
+    }
+
+    #[test]
+    fn test_append_deduplicates_tags() {
+        let (_dir, store) = test_store();
+        let tags = vec!["rust".to_string(), "RUST".to_string(), "rust".to_string()];
+        let id = store.append("test", &tags).unwrap();
+        let memory = store.get(&id).unwrap().unwrap();
+        assert_eq!(memory.tags, vec!["rust"]); // deduped to one
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -154,6 +154,7 @@ fn write_file(path: &PathBuf, memories: &[Memory]) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[must_use]
 pub fn parse_tag_line(line: &str) -> Vec<String> {
     let trimmed = line.trim();
     if !trimmed.starts_with('#') {
@@ -169,7 +170,8 @@ pub fn parse_tag_line(line: &str) -> Vec<String> {
             .collect::<String>()
             .to_lowercase();
         let tag = normalized.trim().to_string();
-        if !tag.is_empty() && seen.insert(tag.clone()) {
+        if !tag.is_empty() && !seen.contains(tag.as_str()) {
+            seen.insert(tag.clone());
             tags.push(tag);
         }
     }
@@ -230,6 +232,14 @@ fn parse_file(date: &str, content: &str) -> Vec<Memory> {
 /// preceding blank line). A line is a tag line if and only if `parse_tag_line`
 /// returns a non-empty result. Body lines after the tag line (or all body lines
 /// if no tag line) form the text.
+///
+/// # Heading/tag ambiguity
+///
+/// Because the first line after the header is always checked as a tag candidate,
+/// a markdown heading like `# intro` placed immediately after `## HH:MM:SS`
+/// (with no blank line in between) **is** treated as a tag line yielding
+/// `["intro"]`. This is intentional spec behavior. To include a markdown heading
+/// as body text, separate it from the timestamp header with a blank line.
 fn build_memory(date: &str, time: &str, body_lines: &[&str]) -> Memory {
     let mut start = 0;
 
@@ -516,14 +526,10 @@ mod tests {
         assert_eq!(parse_tag_line("#rust/lang"), vec!["rustlang"]);
     }
 
-    fn parse_file_pub(date: &str, content: &str) -> Vec<Memory> {
-        parse_file(date, content)
-    }
-
     #[test]
     fn test_parse_file_with_tag_line() {
         let content = "## 14:32:05\n#rust, #til\n\nborrow checker is tricky\n\n";
-        let memories = parse_file_pub("2026-03-11", content);
+        let memories = parse_file("2026-03-11", content);
         assert_eq!(memories.len(), 1);
         assert_eq!(memories[0].tags, vec!["rust", "til"]);
         assert_eq!(memories[0].text, "borrow checker is tricky");
@@ -532,7 +538,7 @@ mod tests {
     #[test]
     fn test_parse_file_without_tag_line_has_empty_tags() {
         let content = "## 15:00:00\n\nwhat do fish think about\n\n";
-        let memories = parse_file_pub("2026-03-11", content);
+        let memories = parse_file("2026-03-11", content);
         assert_eq!(memories.len(), 1);
         assert!(memories[0].tags.is_empty());
         assert_eq!(memories[0].text, "what do fish think about");
@@ -541,7 +547,7 @@ mod tests {
     #[test]
     fn test_parse_file_multiword_tag() {
         let content = "## 16:00:00\n#shower thought\n\nwhy is water wet\n\n";
-        let memories = parse_file_pub("2026-03-11", content);
+        let memories = parse_file("2026-03-11", content);
         assert_eq!(memories[0].tags, vec!["shower thought"]);
         assert_eq!(memories[0].text, "why is water wet");
     }
@@ -550,7 +556,7 @@ mod tests {
     fn test_parse_file_hash_in_body_not_treated_as_tag_line() {
         // A markdown heading in the body should NOT be parsed as a tag line
         let content = "## 10:00:00\n\n# not a tag\n\nsome text\n\n";
-        let memories = parse_file_pub("2026-03-11", content);
+        let memories = parse_file("2026-03-11", content);
         assert_eq!(memories.len(), 1);
         assert!(memories[0].tags.is_empty());
         assert!(memories[0].text.contains("# not a tag"));
@@ -559,7 +565,7 @@ mod tests {
     #[test]
     fn test_parse_file_two_entries_both_tagged() {
         let content = "## 09:00:00\n#morning\n\nfirst\n\n## 10:00:00\n#rust\n\nsecond\n\n";
-        let memories = parse_file_pub("2026-03-11", content);
+        let memories = parse_file("2026-03-11", content);
         assert_eq!(memories.len(), 2);
         assert_eq!(memories[0].tags, vec!["morning"]);
         assert_eq!(memories[1].tags, vec!["rust"]);
@@ -572,5 +578,16 @@ mod tests {
         assert_eq!(memories.len(), 1);
         assert_eq!(memories[0].tags, vec!["rust"]);
         assert_eq!(memories[0].text, "borrow checker");
+    }
+
+    #[test]
+    fn test_parse_file_heading_without_blank_immediately_after_header_is_tag() {
+        // Per spec: the first line after the timestamp is always checked as a tag candidate.
+        // A markdown heading like "# intro" immediately after the header (no blank line)
+        // is treated as a tag line yielding ["intro"]. To avoid this, leave a blank line.
+        let content = "## 10:00:00\n# intro\n\nsome text\n\n";
+        let memories = parse_file("2026-03-11", content);
+        assert_eq!(memories[0].tags, vec!["intro"]);
+        assert_eq!(memories[0].text, "some text");
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -227,25 +227,18 @@ fn parse_file(date: &str, content: &str) -> Vec<Memory> {
 
 /// Build a Memory from raw body lines, extracting the tag line if present.
 /// The tag line must be the very first line after the timestamp header (no
-/// preceding blank line). Body lines after the tag line (or all body lines
+/// preceding blank line). A line is a tag line if and only if `parse_tag_line`
+/// returns a non-empty result. Body lines after the tag line (or all body lines
 /// if no tag line) form the text.
 fn build_memory(date: &str, time: &str, body_lines: &[&str]) -> Memory {
     let mut start = 0;
 
-    // Check if the very first line is a tag line (no blank line before it).
-    // A tag line starts with '#' immediately followed by a non-space character,
-    // distinguishing it from markdown headings like "# Heading".
+    // Delegate tag-line detection entirely to parse_tag_line.
     let tags = if let Some(first) = body_lines.first() {
-        let is_tag_line = first.starts_with('#')
-            && first.chars().nth(1).map_or(false, |c| c != ' ');
-        if is_tag_line {
-            let parsed = parse_tag_line(first);
-            if !parsed.is_empty() {
-                start = 1; // consume tag line
-                parsed
-            } else {
-                vec![]
-            }
+        let candidate_tags = parse_tag_line(first);
+        if !candidate_tags.is_empty() {
+            start = 1; // consume tag line
+            candidate_tags
         } else {
             vec![]
         }
@@ -570,5 +563,14 @@ mod tests {
         assert_eq!(memories.len(), 2);
         assert_eq!(memories[0].tags, vec!["morning"]);
         assert_eq!(memories[1].tags, vec!["rust"]);
+    }
+
+    #[test]
+    fn test_parse_file_space_after_hash_is_tag_line() {
+        let content = "## 14:32:05\n# rust\n\nborrow checker\n\n";
+        let memories = parse_file("2026-03-11", content);
+        assert_eq!(memories.len(), 1);
+        assert_eq!(memories[0].tags, vec!["rust"]);
+        assert_eq!(memories[0].text, "borrow checker");
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -35,7 +35,7 @@ impl Store {
         Self::new(crate::config::memories_dir())
     }
 
-    pub fn append(&self, text: &str) -> anyhow::Result<String> {
+    pub fn append(&self, text: &str, tags: &[String]) -> anyhow::Result<String> {
         let now = chrono::Local::now();
         let date = now.format("%Y-%m-%d").to_string();
         let time = now.format("%H:%M:%S").to_string();
@@ -44,7 +44,22 @@ impl Store {
         let file_path = self.memories_dir.join(format!("{}.md", date));
 
         let text = text.trim();
-        let entry = format!("## {}\n\n{}\n\n", time, text);
+        let mut entry = format!("## {}\n", time);
+
+        // Normalize tags, preserve input order, deduplicate
+        let mut seen = std::collections::HashSet::new();
+        let ordered: Vec<String> = tags
+            .iter()
+            .filter_map(|t| normalize_tag(t))
+            .filter(|t| seen.insert(t.clone()))
+            .collect();
+
+        if !ordered.is_empty() {
+            let tag_line = ordered.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(", ");
+            entry.push_str(&format!("{}\n", tag_line));
+        }
+        entry.push_str(&format!("\n{}\n\n", text));
+
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -148,10 +163,31 @@ fn parse_id(id: &str) -> anyhow::Result<(String, String)> {
 fn write_file(path: &PathBuf, memories: &[Memory]) -> anyhow::Result<()> {
     let mut content = String::new();
     for m in memories {
-        content.push_str(&format!("## {}\n\n{}\n\n", m.time, m.text));
+        content.push_str(&format!("## {}\n", m.time));
+        if !m.tags.is_empty() {
+            let tag_line = m.tags
+                .iter()
+                .map(|t| format!("#{}", t))
+                .collect::<Vec<_>>()
+                .join(", ");
+            content.push_str(&format!("{}\n", tag_line));
+        }
+        content.push_str(&format!("\n{}\n\n", m.text));
     }
     std::fs::write(path, content)?;
     Ok(())
+}
+
+/// Normalize a single tag string: lowercase, strip disallowed chars, trim.
+/// Returns `None` if the result is empty.
+fn normalize_tag(raw: &str) -> Option<String> {
+    let normalized: String = raw
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == ' ' || *c == '-')
+        .collect::<String>()
+        .to_lowercase();
+    let tag = normalized.trim().to_string();
+    if tag.is_empty() { None } else { Some(tag) }
 }
 
 #[must_use]
@@ -164,15 +200,11 @@ pub fn parse_tag_line(line: &str) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     for part in trimmed.split(',') {
         let raw = part.trim().strip_prefix('#').unwrap_or("").trim();
-        let normalized: String = raw
-            .chars()
-            .filter(|c| c.is_alphanumeric() || *c == ' ' || *c == '-')
-            .collect::<String>()
-            .to_lowercase();
-        let tag = normalized.trim().to_string();
-        if !tag.is_empty() && !seen.contains(tag.as_str()) {
-            seen.insert(tag.clone());
-            tags.push(tag);
+        if let Some(tag) = normalize_tag(raw) {
+            if !seen.contains(tag.as_str()) {
+                seen.insert(tag.clone());
+                tags.push(tag);
+            }
         }
     }
     tags
@@ -295,7 +327,7 @@ mod tests {
     #[test]
     fn test_append_creates_file_with_correct_format() {
         let (_dir, store) = test_store();
-        let id = store.append("hello world").unwrap();
+        let id = store.append("hello world", &[]).unwrap();
 
         // id must be "YYYY-MM-DD/HH:MM:SS"
         let parts: Vec<&str> = id.splitn(2, '/').collect();
@@ -314,8 +346,8 @@ mod tests {
     #[test]
     fn test_append_twice_same_file_keeps_both() {
         let (_dir, store) = test_store();
-        store.append("first").unwrap();
-        store.append("second").unwrap();
+        store.append("first", &[]).unwrap();
+        store.append("second", &[]).unwrap();
 
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
         let file_path = store.memories_dir.join(format!("{}.md", today));
@@ -589,5 +621,49 @@ mod tests {
         let memories = parse_file("2026-03-11", content);
         assert_eq!(memories[0].tags, vec!["intro"]);
         assert_eq!(memories[0].text, "some text");
+    }
+
+    #[test]
+    fn test_write_file_emits_tag_line() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        let mut m = Memory::new("2026-03-11", "14:32:05", "borrow checker");
+        m.tags = vec!["rust".to_string(), "til".to_string()];
+        write_file(&file_path, &[m]).unwrap();
+        let content = std::fs::read_to_string(&file_path).unwrap();
+        assert!(content.contains("#rust, #til"), "tag line missing: {}", content);
+    }
+
+    #[test]
+    fn test_write_file_no_tag_line_when_empty() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        let m = Memory::new("2026-03-11", "14:32:05", "no tags");
+        write_file(&file_path, &[m]).unwrap();
+        let content = std::fs::read_to_string(&file_path).unwrap();
+        // No tag line should appear; the only '#' chars are in the '## HH:MM:SS' header
+        assert!(!content.lines().any(|l| l.starts_with('#') && !l.starts_with("##")),
+            "unexpected tag line in content: {}", content);
+    }
+
+    #[test]
+    fn test_append_with_tags_writes_tag_line() {
+        let (_dir, store) = test_store();
+        let tags = vec!["rust".to_string(), "til".to_string()];
+        let id = store.append("learned lifetimes", &tags).unwrap();
+        let memory = store.get(&id).unwrap().unwrap();
+        assert_eq!(memory.tags, vec!["rust", "til"]);
+        assert_eq!(memory.text, "learned lifetimes");
+    }
+
+    #[test]
+    fn test_append_without_tags_backward_compat() {
+        let (_dir, store) = test_store();
+        let id = store.append("plain thought", &[]).unwrap();
+        let memory = store.get(&id).unwrap().unwrap();
+        assert!(memory.tags.is_empty());
+        assert_eq!(memory.text, "plain thought");
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -7,6 +7,7 @@ pub struct Memory {
     pub date: String, // "2026-03-10"
     pub time: String, // "14:32:05"
     pub text: String,
+    pub tags: Vec<String>,
 }
 
 impl Memory {
@@ -16,6 +17,7 @@ impl Memory {
             date: date.to_string(),
             time: time.to_string(),
             text: text.to_string(),
+            tags: vec![],
         }
     }
 }
@@ -393,5 +395,11 @@ mod tests {
         let memory = store.get("2026-03-10/14:32").unwrap();
         assert!(memory.is_some());
         assert_eq!(memory.unwrap().text, "legacy entry");
+    }
+
+    #[test]
+    fn test_memory_new_has_empty_tags_by_default() {
+        let m = Memory::new("2026-03-10", "14:32:05", "hello");
+        assert!(m.tags.is_empty());
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -129,6 +129,43 @@ impl Store {
         write_file(&file_path, &memories)
     }
 
+    pub fn add_tags(&self, id: &str, new_tags: &[String]) -> anyhow::Result<()> {
+        let (date, time) = parse_id(id)?;
+        let file_path = self.memories_dir.join(format!("{}.md", date));
+        anyhow::ensure!(file_path.exists(), "Memory not found: {}", id);
+        let content = std::fs::read_to_string(&file_path)?;
+        let mut memories = parse_file(&date, &content);
+        let entry = memories
+            .iter_mut()
+            .find(|m| m.time == time)
+            .ok_or_else(|| anyhow::anyhow!("Memory not found: {}", id))?;
+        let mut seen: std::collections::HashSet<String> = entry.tags.iter().cloned().collect();
+        for raw in new_tags {
+            if let Some(normalized) = normalize_tag(raw) {
+                if seen.insert(normalized.clone()) {
+                    entry.tags.push(normalized);
+                }
+            }
+        }
+        write_file(&file_path, &memories)
+    }
+
+    pub fn remove_tags(&self, id: &str, tags_to_remove: &[String]) -> anyhow::Result<()> {
+        let (date, time) = parse_id(id)?;
+        let file_path = self.memories_dir.join(format!("{}.md", date));
+        anyhow::ensure!(file_path.exists(), "Memory not found: {}", id);
+        let content = std::fs::read_to_string(&file_path)?;
+        let mut memories = parse_file(&date, &content);
+        let entry = memories
+            .iter_mut()
+            .find(|m| m.time == time)
+            .ok_or_else(|| anyhow::anyhow!("Memory not found: {}", id))?;
+        let to_remove: std::collections::HashSet<String> =
+            tags_to_remove.iter().filter_map(|t| normalize_tag(t)).collect();
+        entry.tags.retain(|t| !to_remove.contains(t));
+        write_file(&file_path, &memories)
+    }
+
     pub fn delete(&self, id: &str) -> anyhow::Result<()> {
         let (date, time) = parse_id(id)?;
         let file_path = self.memories_dir.join(format!("{}.md", date));
@@ -687,5 +724,88 @@ mod tests {
         let id = store.append("test", &tags).unwrap();
         let memory = store.get(&id).unwrap().unwrap();
         assert_eq!(memory.tags, vec!["rust"]); // deduped to one
+    }
+
+    #[test]
+    fn test_add_tags_to_existing_memory() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        std::fs::write(&file_path, "## 14:32:05\n\nborrow checker\n\n").unwrap();
+
+        store.add_tags("2026-03-11/14:32:05", &["rust".to_string(), "til".to_string()]).unwrap();
+        let m = store.get("2026-03-11/14:32:05").unwrap().unwrap();
+        assert_eq!(m.tags, vec!["rust", "til"]);
+        assert_eq!(m.text, "borrow checker");
+    }
+
+    #[test]
+    fn test_add_tags_merges_with_existing() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        std::fs::write(&file_path, "## 14:32:05\n#rust\n\nborrow checker\n\n").unwrap();
+
+        store.add_tags("2026-03-11/14:32:05", &["til".to_string()]).unwrap();
+        let m = store.get("2026-03-11/14:32:05").unwrap().unwrap();
+        assert!(m.tags.contains(&"rust".to_string()));
+        assert!(m.tags.contains(&"til".to_string()));
+    }
+
+    #[test]
+    fn test_add_tags_duplicate_is_noop() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        std::fs::write(&file_path, "## 14:32:05\n#rust\n\nborrow checker\n\n").unwrap();
+
+        store.add_tags("2026-03-11/14:32:05", &["rust".to_string()]).unwrap();
+        let m = store.get("2026-03-11/14:32:05").unwrap().unwrap();
+        assert_eq!(m.tags, vec!["rust"]); // still only one
+    }
+
+    #[test]
+    fn test_add_tags_nonexistent_id_errors() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let result = store.add_tags("2026-03-11/99:99:99", &["rust".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_remove_tags_from_memory() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        std::fs::write(&file_path, "## 14:32:05\n#rust, #til\n\nborrow checker\n\n").unwrap();
+
+        store.remove_tags("2026-03-11/14:32:05", &["til".to_string()]).unwrap();
+        let m = store.get("2026-03-11/14:32:05").unwrap().unwrap();
+        assert_eq!(m.tags, vec!["rust"]);
+    }
+
+    #[test]
+    fn test_remove_nonexistent_tag_is_noop() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        std::fs::write(&file_path, "## 14:32:05\n#rust\n\nborrow checker\n\n").unwrap();
+
+        store.remove_tags("2026-03-11/14:32:05", &["til".to_string()]).unwrap();
+        let m = store.get("2026-03-11/14:32:05").unwrap().unwrap();
+        assert_eq!(m.tags, vec!["rust"]); // unchanged
+    }
+
+    #[test]
+    fn test_remove_all_tags_leaves_empty_tags() {
+        let (_dir, store) = test_store();
+        std::fs::create_dir_all(&store.memories_dir).unwrap();
+        let file_path = store.memories_dir.join("2026-03-11.md");
+        std::fs::write(&file_path, "## 14:32:05\n#rust\n\nborrow checker\n\n").unwrap();
+
+        store.remove_tags("2026-03-11/14:32:05", &["rust".to_string()]).unwrap();
+        let m = store.get("2026-03-11/14:32:05").unwrap().unwrap();
+        assert!(m.tags.is_empty());
+        assert_eq!(m.text, "borrow checker"); // text preserved
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -154,6 +154,28 @@ fn write_file(path: &PathBuf, memories: &[Memory]) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn parse_tag_line(line: &str) -> Vec<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('#') {
+        return vec![];
+    }
+    let mut tags = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for part in trimmed.split(',') {
+        let raw = part.trim().strip_prefix('#').unwrap_or("").trim();
+        let normalized: String = raw
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == ' ' || *c == '-')
+            .collect::<String>()
+            .to_lowercase();
+        let tag = normalized.trim().to_string();
+        if !tag.is_empty() && seen.insert(tag.clone()) {
+            tags.push(tag);
+        }
+    }
+    tags
+}
+
 fn parse_time_header(line: &str) -> Option<String> {
     let rest = line.strip_prefix("## ")?;
     // Accept HH:MM:SS (new format) or HH:MM (backward compat for existing files)
@@ -401,5 +423,65 @@ mod tests {
     fn test_memory_new_has_empty_tags_by_default() {
         let m = Memory::new("2026-03-10", "14:32:05", "hello");
         assert!(m.tags.is_empty());
+    }
+
+    #[test]
+    fn test_parse_tag_line_empty() {
+        assert!(parse_tag_line("").is_empty());
+    }
+
+    #[test]
+    fn test_parse_tag_line_no_hash() {
+        assert!(parse_tag_line("no hash prefix").is_empty());
+    }
+
+    #[test]
+    fn test_parse_tag_line_single_tag() {
+        assert_eq!(parse_tag_line("#rust"), vec!["rust"]);
+    }
+
+    #[test]
+    fn test_parse_tag_line_multiple_tags() {
+        assert_eq!(parse_tag_line("#rust, #til"), vec!["rust", "til"]);
+    }
+
+    #[test]
+    fn test_parse_tag_line_multiword_tag() {
+        assert_eq!(parse_tag_line("#shower thought, #rust"), vec!["shower thought", "rust"]);
+    }
+
+    #[test]
+    fn test_parse_tag_line_dedup_and_lowercase() {
+        assert_eq!(parse_tag_line("#Rust, #RUST, #rust"), vec!["rust"]);
+    }
+
+    #[test]
+    fn test_parse_tag_line_whitespace_trimmed() {
+        assert_eq!(parse_tag_line("  #rust  ,  #til  "), vec!["rust", "til"]);
+    }
+
+    #[test]
+    fn test_parse_tag_line_bare_hash_ignored() {
+        assert!(parse_tag_line("#").is_empty());
+    }
+
+    #[test]
+    fn test_parse_tag_line_empty_tag_part_skipped() {
+        assert_eq!(parse_tag_line("#, #rust"), vec!["rust"]);
+    }
+
+    #[test]
+    fn test_parse_tag_line_plain_text_is_not_tag_line() {
+        assert!(parse_tag_line("just some text").is_empty());
+    }
+
+    #[test]
+    fn test_parse_tag_line_strips_underscore() {
+        assert_eq!(parse_tag_line("#rust_lang"), vec!["rustlang"]);
+    }
+
+    #[test]
+    fn test_parse_tag_line_strips_slash() {
+        assert_eq!(parse_tag_line("#rust/lang"), vec!["rustlang"]);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -203,9 +203,9 @@ fn parse_file(date: &str, content: &str) -> Vec<Memory> {
     for line in content.lines() {
         if let Some(time) = parse_time_header(line) {
             if let Some(ref t) = current_time {
-                let text = current_body.join("\n").trim().to_string();
-                if !text.is_empty() {
-                    memories.push(Memory::new(date, t, &text));
+                let memory = build_memory(date, t, &current_body);
+                if !memory.text.is_empty() {
+                    memories.push(memory);
                 }
             }
             current_time = Some(time);
@@ -216,13 +216,51 @@ fn parse_file(date: &str, content: &str) -> Vec<Memory> {
     }
 
     if let Some(ref t) = current_time {
-        let text = current_body.join("\n").trim().to_string();
-        if !text.is_empty() {
-            memories.push(Memory::new(date, t, &text));
+        let memory = build_memory(date, t, &current_body);
+        if !memory.text.is_empty() {
+            memories.push(memory);
         }
     }
 
     memories
+}
+
+/// Build a Memory from raw body lines, extracting the tag line if present.
+/// The tag line must be the very first line after the timestamp header (no
+/// preceding blank line). Body lines after the tag line (or all body lines
+/// if no tag line) form the text.
+fn build_memory(date: &str, time: &str, body_lines: &[&str]) -> Memory {
+    let mut start = 0;
+
+    // Check if the very first line is a tag line (no blank line before it).
+    // A tag line starts with '#' immediately followed by a non-space character,
+    // distinguishing it from markdown headings like "# Heading".
+    let tags = if let Some(first) = body_lines.first() {
+        let is_tag_line = first.starts_with('#')
+            && first.chars().nth(1).map_or(false, |c| c != ' ');
+        if is_tag_line {
+            let parsed = parse_tag_line(first);
+            if !parsed.is_empty() {
+                start = 1; // consume tag line
+                parsed
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        }
+    } else {
+        vec![]
+    };
+
+    let text = body_lines[start..]
+        .join("\n")
+        .trim()
+        .to_string();
+
+    let mut m = Memory::new(date, time, &text);
+    m.tags = tags;
+    m
 }
 
 #[cfg(test)]
@@ -483,5 +521,54 @@ mod tests {
     #[test]
     fn test_parse_tag_line_strips_slash() {
         assert_eq!(parse_tag_line("#rust/lang"), vec!["rustlang"]);
+    }
+
+    fn parse_file_pub(date: &str, content: &str) -> Vec<Memory> {
+        parse_file(date, content)
+    }
+
+    #[test]
+    fn test_parse_file_with_tag_line() {
+        let content = "## 14:32:05\n#rust, #til\n\nborrow checker is tricky\n\n";
+        let memories = parse_file_pub("2026-03-11", content);
+        assert_eq!(memories.len(), 1);
+        assert_eq!(memories[0].tags, vec!["rust", "til"]);
+        assert_eq!(memories[0].text, "borrow checker is tricky");
+    }
+
+    #[test]
+    fn test_parse_file_without_tag_line_has_empty_tags() {
+        let content = "## 15:00:00\n\nwhat do fish think about\n\n";
+        let memories = parse_file_pub("2026-03-11", content);
+        assert_eq!(memories.len(), 1);
+        assert!(memories[0].tags.is_empty());
+        assert_eq!(memories[0].text, "what do fish think about");
+    }
+
+    #[test]
+    fn test_parse_file_multiword_tag() {
+        let content = "## 16:00:00\n#shower thought\n\nwhy is water wet\n\n";
+        let memories = parse_file_pub("2026-03-11", content);
+        assert_eq!(memories[0].tags, vec!["shower thought"]);
+        assert_eq!(memories[0].text, "why is water wet");
+    }
+
+    #[test]
+    fn test_parse_file_hash_in_body_not_treated_as_tag_line() {
+        // A markdown heading in the body should NOT be parsed as a tag line
+        let content = "## 10:00:00\n\n# not a tag\n\nsome text\n\n";
+        let memories = parse_file_pub("2026-03-11", content);
+        assert_eq!(memories.len(), 1);
+        assert!(memories[0].tags.is_empty());
+        assert!(memories[0].text.contains("# not a tag"));
+    }
+
+    #[test]
+    fn test_parse_file_two_entries_both_tagged() {
+        let content = "## 09:00:00\n#morning\n\nfirst\n\n## 10:00:00\n#rust\n\nsecond\n\n";
+        let memories = parse_file_pub("2026-03-11", content);
+        assert_eq!(memories.len(), 2);
+        assert_eq!(memories[0].tags, vec!["morning"]);
+        assert_eq!(memories[1].tags, vec!["rust"]);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -37,6 +37,8 @@ pub struct App {
     pub should_quit: bool,
     pub active_tag_filter: Option<String>,
     pub tag_picker_selected: usize,
+    pub add_tags_input: String,
+    pub add_focused_tags: bool,
 }
 
 impl App {
@@ -54,6 +56,8 @@ impl App {
             should_quit: false,
             active_tag_filter: None,
             tag_picker_selected: 0,
+            add_tags_input: String::new(),
+            add_focused_tags: false,
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -22,6 +22,7 @@ pub enum Mode {
     Delete,
     SemanticSearch(SearchState),
     View,
+    TagFilter,
 }
 
 pub struct App {
@@ -34,6 +35,8 @@ pub struct App {
     pub search_rx: Option<Receiver<SearchResult>>,
     pub error: Option<String>,
     pub should_quit: bool,
+    pub active_tag_filter: Option<String>,
+    pub tag_picker_selected: usize,
 }
 
 impl App {
@@ -49,6 +52,8 @@ impl App {
             search_rx: None,
             error: None,
             should_quit: false,
+            active_tag_filter: None,
+            tag_picker_selected: 0,
         }
     }
 
@@ -176,5 +181,19 @@ mod tests {
     fn test_app_selected_memory_returns_none_when_empty() {
         let app = App::from_memories(vec![]);
         assert!(app.selected_memory().is_none());
+    }
+
+    #[test]
+    fn test_app_has_no_active_tag_filter_by_default() {
+        let app = App::from_memories(vec![make_memory("2026-03-10/14:00:00", "first")]);
+        assert!(app.active_tag_filter.is_none());
+        assert_eq!(app.tag_picker_selected, 0);
+    }
+
+    #[test]
+    fn test_tag_filter_mode_exists() {
+        let mut app = App::from_memories(vec![make_memory("2026-03-10/14:00:00", "first")]);
+        app.mode = Mode::TagFilter;
+        assert_eq!(app.mode, Mode::TagFilter);
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -11,5 +11,6 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
         // All SemanticSearch states (Typing, Loading, Results) handled by search view
         Mode::SemanticSearch(_) => views::search::handle_key(app, key),
         Mode::View => views::thought::handle_key(app, key),
+        Mode::TagFilter => {} // handled in Task 14
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -11,6 +11,6 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
         // All SemanticSearch states (Typing, Loading, Results) handled by search view
         Mode::SemanticSearch(_) => views::search::handle_key(app, key),
         Mode::View => views::thought::handle_key(app, key),
-        Mode::TagFilter => {} // handled in Task 14
+        Mode::TagFilter => views::tags::handle_key(app, key),
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -25,7 +25,7 @@ pub fn render(app: &App, frame: &mut Frame) {
         }
         Mode::TagFilter => {
             views::list::render(app, frame, area);
-            // tags modal rendered in Task 14
+            views::tags::render(app, frame, area);
         }
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -23,5 +23,9 @@ pub fn render(app: &App, frame: &mut Frame) {
             views::list::render(app, frame, area);
             views::thought::render(app, frame, area);
         }
+        Mode::TagFilter => {
+            views::list::render(app, frame, area);
+            // tags modal rendered in Task 14
+        }
     }
 }

--- a/src/tui/views/add.rs
+++ b/src/tui/views/add.rs
@@ -55,7 +55,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
                 return;
             }
             let store = crate::store::Store::from_config();
-            match store.append(&text) {
+            match store.append(&text, &[]) {
                 Ok(id) => {
                     let text_clone = text.clone();
                     let id_clone = id.clone();

--- a/src/tui/views/add.rs
+++ b/src/tui/views/add.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 pub fn render(app: &App, frame: &mut Frame, area: Rect) {
-    let modal = centered_rect(60, 7, area);
+    let modal = centered_rect(60, 9, area);
     frame.render_widget(Clear, modal);
 
     let block = Block::default()
@@ -21,41 +21,74 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
     let inner = block.inner(modal);
     frame.render_widget(block, modal);
 
-    // Split inner area: 1 line padding top, 1 line content, 1 line padding, 1 line hint
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
+            Constraint::Length(1), // top padding
+            Constraint::Length(1), // thought field
+            Constraint::Length(1), // gap
+            Constraint::Length(1), // tags field
+            Constraint::Length(1), // gap
+            Constraint::Length(1), // hint
+            Constraint::Length(1), // bottom padding
         ])
         .split(inner);
 
-    let content = format!("Thought: {}\u{2588}", app.input);
-    let content_widget = Paragraph::new(content)
-        .style(Style::default().fg(Color::White));
-    frame.render_widget(content_widget, chunks[1]);
+    let thought_cursor = if !app.add_focused_tags { "\u{2588}" } else { "" };
+    let thought_style = if !app.add_focused_tags {
+        Style::default().fg(Color::White)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let thought_content = format!("Thought: {}{}", app.input, thought_cursor);
+    frame.render_widget(
+        Paragraph::new(thought_content).style(thought_style),
+        chunks[1],
+    );
 
-    let hint = Paragraph::new("[Enter to save · Esc cancel]")
+    let tags_cursor = if app.add_focused_tags { "\u{2588}" } else { "" };
+    let tags_style = if app.add_focused_tags {
+        Style::default().fg(Color::White)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let tags_content = format!("Tags:    {}{}", app.add_tags_input, tags_cursor);
+    frame.render_widget(
+        Paragraph::new(tags_content).style(tags_style),
+        chunks[3],
+    );
+
+    let hint = Paragraph::new("[Tab switch field · Enter save · Esc cancel]")
         .style(Style::default().fg(Color::DarkGray))
         .alignment(Alignment::Center);
-    frame.render_widget(hint, chunks[3]);
+    frame.render_widget(hint, chunks[5]);
 }
 
 pub fn handle_key(app: &mut App, key: KeyEvent) {
     match key.code {
         KeyCode::Esc => {
             app.input.clear();
+            app.add_tags_input.clear();
+            app.add_focused_tags = false;
             app.mode = Mode::List;
+        }
+        KeyCode::Tab => {
+            app.add_focused_tags = !app.add_focused_tags;
         }
         KeyCode::Enter => {
             let text = app.input.trim().to_string();
             if text.is_empty() {
                 return;
             }
+            let tags: Vec<String> = app
+                .add_tags_input
+                .split(',')
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect();
+
             let store = crate::store::Store::from_config();
-            match store.append(&text, &[]) {
+            match store.append(&text, &tags) {
                 Ok(id) => {
                     let text_clone = text.clone();
                     let id_clone = id.clone();
@@ -72,6 +105,8 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
                         }
                     });
                     app.input.clear();
+                    app.add_tags_input.clear();
+                    app.add_focused_tags = false;
                     let _ = app.reload_memories();
                     app.mode = Mode::List;
                 }
@@ -81,10 +116,18 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
             }
         }
         KeyCode::Backspace => {
-            app.input.pop();
+            if app.add_focused_tags {
+                app.add_tags_input.pop();
+            } else {
+                app.input.pop();
+            }
         }
         KeyCode::Char(c) => {
-            app.input.push(c);
+            if app.add_focused_tags {
+                app.add_tags_input.push(c);
+            } else {
+                app.input.push(c);
+            }
         }
         _ => {}
     }
@@ -128,30 +171,67 @@ mod tests {
     }
 
     #[test]
-    fn test_typing_updates_input() {
+    fn test_typing_updates_thought_input() {
         let mut app = empty_app();
         app.mode = Mode::Add;
         handle_key(&mut app, key(KeyCode::Char('h')));
         handle_key(&mut app, key(KeyCode::Char('i')));
         assert_eq!(app.input, "hi");
+        assert!(app.add_tags_input.is_empty());
     }
 
     #[test]
-    fn test_backspace_removes_char() {
+    fn test_tab_switches_to_tags_field() {
+        let mut app = empty_app();
+        app.mode = Mode::Add;
+        assert!(!app.add_focused_tags);
+        handle_key(&mut app, key(KeyCode::Tab));
+        assert!(app.add_focused_tags);
+    }
+
+    #[test]
+    fn test_typing_in_tags_field_updates_tags_input() {
+        let mut app = empty_app();
+        app.mode = Mode::Add;
+        app.add_focused_tags = true;
+        handle_key(&mut app, key(KeyCode::Char('r')));
+        handle_key(&mut app, key(KeyCode::Char('u')));
+        handle_key(&mut app, key(KeyCode::Char('s')));
+        handle_key(&mut app, key(KeyCode::Char('t')));
+        assert_eq!(app.add_tags_input, "rust");
+        assert!(app.input.is_empty());
+    }
+
+    #[test]
+    fn test_backspace_removes_from_active_field() {
         let mut app = empty_app();
         app.input = "hello".to_string();
+        app.add_tags_input = "rust".to_string();
+
+        // backspace on thought field
         handle_key(&mut app, key(KeyCode::Backspace));
+        assert_eq!(app.input, "hell");
+        assert_eq!(app.add_tags_input, "rust");
+
+        // switch to tags and backspace
+        app.add_focused_tags = true;
+        handle_key(&mut app, key(KeyCode::Backspace));
+        assert_eq!(app.add_tags_input, "rus");
         assert_eq!(app.input, "hell");
     }
 
     #[test]
-    fn test_esc_clears_input_and_returns_to_list() {
+    fn test_esc_clears_both_fields_and_returns_to_list() {
         let mut app = empty_app();
         app.mode = Mode::Add;
         app.input = "draft".to_string();
+        app.add_tags_input = "rust".to_string();
+        app.add_focused_tags = true;
         handle_key(&mut app, key(KeyCode::Esc));
         assert_eq!(app.mode, Mode::List);
         assert!(app.input.is_empty());
+        assert!(app.add_tags_input.is_empty());
+        assert!(!app.add_focused_tags);
     }
 
     #[test]

--- a/src/tui/views/list.rs
+++ b/src/tui/views/list.rs
@@ -1,3 +1,4 @@
+use crate::cli::list::format_tag_block;
 use crate::tui::app::{App, Mode, SearchState};
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
@@ -96,7 +97,11 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
         .map(|(i, memory)| {
             // list_area has no borders; prefix = "> " + index(3) + "  " + id(19) + "  " = 28 chars
             // subtract 1 more so the "…" character fits without being clipped
-            let text_max = (list_area.width as usize).saturating_sub(29).max(1);
+            let tag_block = format_tag_block(memory);
+            let tag_len = tag_block.chars().count();
+            let text_max = (list_area.width as usize)
+                .saturating_sub(29 + tag_len)
+                .max(1);
             let text_display = if memory.text.chars().count() > text_max {
                 let truncated: String = memory.text.chars().take(text_max).collect();
                 format!("{}…", truncated)
@@ -105,11 +110,11 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
             };
 
             if i == app.selected {
-                let line = format!("> {:>3}  {}  {}", i + 1, memory.id, text_display);
+                let line = format!("> {:>3}  {}  {}{}", i + 1, memory.id, tag_block, text_display);
                 ListItem::new(line)
                     .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))
             } else {
-                let line = format!("  {:>3}  {}  {}", i + 1, memory.id, text_display);
+                let line = format!("  {:>3}  {}  {}{}", i + 1, memory.id, tag_block, text_display);
                 ListItem::new(line)
             }
         })
@@ -366,5 +371,20 @@ mod tests {
         assert_eq!(app.selected, 1);
         handle_fuzzy_key(&mut app, key(KeyCode::Char('k')));
         assert_eq!(app.selected, 0);
+    }
+
+    #[test]
+    fn test_list_row_tag_block_empty() {
+        use crate::store::Memory;
+        let m = Memory::new("2026-03-11", "10:00:00", "borrow checker");
+        assert_eq!(crate::cli::list::format_tag_block(&m), "");
+    }
+
+    #[test]
+    fn test_list_row_tag_block_shows_tags() {
+        use crate::store::Memory;
+        let mut m = Memory::new("2026-03-11", "10:00:00", "borrow checker");
+        m.tags = vec!["rust".to_string(), "til".to_string()];
+        assert_eq!(crate::cli::list::format_tag_block(&m), "[#rust, #til] ");
     }
 }

--- a/src/tui/views/list.rs
+++ b/src/tui/views/list.rs
@@ -22,7 +22,13 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
         Mode::FuzzyFilter | Mode::SemanticSearch(SearchState::Results)
     );
 
-    let (border_color, border_type, title_right) = if is_filtered {
+    let (border_color, border_type, title_right) = if let Some(tag) = &app.active_tag_filter {
+        (
+            Color::Cyan,
+            BorderType::Double,
+            format!(" [tag: #{}] ", tag),
+        )
+    } else if is_filtered {
         let query = if app.input.chars().count() > 20 {
             let truncated: String = app.input.chars().take(20).collect();
             format!("{}…", truncated)
@@ -38,11 +44,14 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
         (Color::Gray, BorderType::Plain, " [List] ".to_string())
     };
 
-    let footer_text = if is_filtered {
+    let footer_text = if let Some(tag) = &app.active_tag_filter {
+        let count = app.visible.len();
+        format!(" Esc to return · {} results · tag: #{} ", count, tag)
+    } else if is_filtered {
         let count = app.visible.len();
         format!(" Esc to return · {} results ", count)
     } else {
-        " / fuzzy · s search · ↵ view · a add · d del · q ".to_string()
+        " / fuzzy · s search · t tag · ↵ view · a add · d del · q ".to_string()
     };
 
     let block = Block::default()
@@ -146,6 +155,17 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
         KeyCode::Char('s') => {
             app.input.clear();
             app.mode = Mode::SemanticSearch(SearchState::Typing);
+        }
+        KeyCode::Char('t') => {
+            app.tag_picker_selected = 0;
+            app.mode = Mode::TagFilter;
+        }
+        KeyCode::Esc => {
+            if app.active_tag_filter.is_some() {
+                app.active_tag_filter = None;
+                app.visible = app.memories.clone();
+                app.selected = 0;
+            }
         }
         KeyCode::Enter => {
             if app.selected_memory().is_some() {
@@ -386,5 +406,27 @@ mod tests {
         let mut m = Memory::new("2026-03-11", "10:00:00", "borrow checker");
         m.tags = vec!["rust".to_string(), "til".to_string()];
         assert_eq!(crate::cli::list::format_tag_block(&m), "[#rust, #til] ");
+    }
+
+    #[test]
+    fn test_t_key_enters_tag_filter_mode() {
+        let mut app = App::from_memories(vec![]);
+        handle_key(&mut app, key(KeyCode::Char('t')));
+        assert_eq!(app.mode, Mode::TagFilter);
+        assert_eq!(app.tag_picker_selected, 0);
+    }
+
+    #[test]
+    fn test_esc_clears_active_tag_filter() {
+        use crate::store::Memory;
+        let mut m = Memory::new("2026-03-11", "10:00:00", "text");
+        m.tags = vec!["rust".to_string()];
+        let mut app = App::from_memories(vec![m]);
+        app.active_tag_filter = Some("rust".to_string());
+        app.visible = app.memories.iter().filter(|m| m.tags.contains(&"rust".to_string())).cloned().collect();
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert!(app.active_tag_filter.is_none());
+        assert_eq!(app.visible.len(), 1); // full list restored
+        assert_eq!(app.selected, 0);
     }
 }

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -3,4 +3,5 @@ pub mod delete;
 pub mod list;
 pub mod search;
 pub mod stats;
+pub mod tags;
 pub mod thought;

--- a/src/tui/views/tags.rs
+++ b/src/tui/views/tags.rs
@@ -1,0 +1,203 @@
+use crate::store::Memory;
+use crate::tui::app::{App, Mode};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{Frame, layout::Rect};
+
+/// Build a sorted list of (tag, count) from memories.
+pub fn all_tags_sorted(memories: &[Memory]) -> Vec<(String, usize)> {
+    use std::collections::HashMap;
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for m in memories {
+        for t in &m.tags {
+            *counts.entry(t.as_str()).or_insert(0) += 1;
+        }
+    }
+    let mut sorted: Vec<(String, usize)> = counts
+        .into_iter()
+        .map(|(t, c)| (t.to_string(), c))
+        .collect();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    sorted
+}
+
+pub fn render(app: &App, frame: &mut Frame, area: Rect) {
+    use ratatui::{
+        layout::{Alignment, Constraint, Direction, Layout},
+        style::{Color, Style},
+        text::Line,
+        widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState},
+    };
+
+    let tags = all_tags_sorted(&app.memories);
+
+    let height = (tags.len() as u16 + 4).min(20).max(5);
+    let modal_area = {
+        let vert = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Fill(1),
+                Constraint::Length(height),
+                Constraint::Fill(1),
+            ])
+            .split(area);
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Percentage(25),
+                Constraint::Percentage(50),
+                Constraint::Percentage(25),
+            ])
+            .split(vert[1])[1]
+    };
+
+    frame.render_widget(Clear, modal_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(Line::from(" Filter by tag ").alignment(Alignment::Center))
+        .title_bottom(Line::from(" ↵ select · Esc cancel ").alignment(Alignment::Center));
+
+    let inner = block.inner(modal_area);
+    frame.render_widget(block, modal_area);
+
+    if tags.is_empty() {
+        let empty = ratatui::widgets::Paragraph::new("No tags yet.")
+            .style(Style::default().fg(Color::Gray))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty, inner);
+        return;
+    }
+
+    let items: Vec<ListItem> = tags
+        .iter()
+        .enumerate()
+        .map(|(i, (tag, count))| {
+            let line = format!("  #{:<20}  {}", tag, count);
+            if i == app.tag_picker_selected {
+                ListItem::new(line).style(Style::default().fg(Color::Yellow))
+            } else {
+                ListItem::new(line)
+            }
+        })
+        .collect();
+
+    let mut state = ListState::default().with_selected(Some(app.tag_picker_selected));
+    frame.render_stateful_widget(List::new(items), inner, &mut state);
+}
+
+pub fn handle_key(app: &mut App, key: KeyEvent) {
+    let tags = all_tags_sorted(&app.memories);
+    match key.code {
+        KeyCode::Esc => {
+            app.mode = Mode::List;
+            app.tag_picker_selected = 0;
+        }
+        KeyCode::Char('j') | KeyCode::Down => {
+            if !tags.is_empty() && app.tag_picker_selected < tags.len() - 1 {
+                app.tag_picker_selected += 1;
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            if app.tag_picker_selected > 0 {
+                app.tag_picker_selected -= 1;
+            }
+        }
+        KeyCode::Enter => {
+            if let Some((tag, _)) = tags.get(app.tag_picker_selected) {
+                let t = tag.clone();
+                app.active_tag_filter = Some(t.clone());
+                app.visible = app.memories.iter().filter(|m| m.tags.contains(&t)).cloned().collect();
+                app.selected = 0;
+                app.mode = Mode::List;
+                app.tag_picker_selected = 0;
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Memory;
+    use crossterm::event::{KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent { code, modifiers: KeyModifiers::NONE, kind: KeyEventKind::Press, state: KeyEventState::NONE }
+    }
+
+    fn make_memory(tags: Vec<&str>) -> Memory {
+        let mut m = Memory::new("2026-03-11", "10:00:00", "text");
+        m.tags = tags.into_iter().map(|s| s.to_string()).collect();
+        m
+    }
+
+    #[test]
+    fn test_all_tags_sorted_empty() {
+        assert!(all_tags_sorted(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_all_tags_sorted_by_count_descending() {
+        let memories = vec![
+            make_memory(vec!["rust", "til"]),
+            make_memory(vec!["rust"]),
+        ];
+        let result = all_tags_sorted(&memories);
+        assert_eq!(result[0].0, "rust");
+        assert_eq!(result[0].1, 2);
+        assert_eq!(result[1].0, "til");
+    }
+
+    #[test]
+    fn test_handle_key_esc_returns_to_list() {
+        let mut app = App::from_memories(vec![make_memory(vec!["rust"])]);
+        app.mode = Mode::TagFilter;
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert_eq!(app.mode, Mode::List);
+        assert_eq!(app.tag_picker_selected, 0);
+        assert!(app.active_tag_filter.is_none()); // Esc does NOT set filter
+    }
+
+    #[test]
+    fn test_handle_key_j_moves_cursor_down() {
+        let memories = vec![
+            make_memory(vec!["rust"]),
+            make_memory(vec!["til"]),
+        ];
+        let mut app = App::from_memories(memories);
+        app.mode = Mode::TagFilter;
+        handle_key(&mut app, key(KeyCode::Char('j')));
+        assert_eq!(app.tag_picker_selected, 1);
+    }
+
+    #[test]
+    fn test_handle_key_k_moves_cursor_up() {
+        let memories = vec![
+            make_memory(vec!["rust"]),
+            make_memory(vec!["til"]),
+        ];
+        let mut app = App::from_memories(memories);
+        app.mode = Mode::TagFilter;
+        app.tag_picker_selected = 1;
+        handle_key(&mut app, key(KeyCode::Char('k')));
+        assert_eq!(app.tag_picker_selected, 0);
+    }
+
+    #[test]
+    fn test_handle_key_enter_sets_filter_and_filters_visible() {
+        let memories = vec![
+            make_memory(vec!["rust"]),
+            make_memory(vec!["til"]),
+        ];
+        let mut app = App::from_memories(memories);
+        app.mode = Mode::TagFilter;
+        app.tag_picker_selected = 0;
+        handle_key(&mut app, key(KeyCode::Enter));
+        assert_eq!(app.mode, Mode::List);
+        assert!(app.active_tag_filter.is_some());
+        assert_eq!(app.visible.len(), 1);
+    }
+}

--- a/src/tui/views/thought.rs
+++ b/src/tui/views/thought.rs
@@ -27,10 +27,25 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
     let inner = block.inner(modal);
     frame.render_widget(block, modal);
 
-    let text_widget = Paragraph::new(memory.text.as_str())
-        .style(Style::default().fg(Color::White))
-        .wrap(Wrap { trim: false });
-    frame.render_widget(text_widget, inner);
+    if memory.tags.is_empty() {
+        let text_widget = Paragraph::new(memory.text.as_str())
+            .style(Style::default().fg(Color::White))
+            .wrap(Wrap { trim: false });
+        frame.render_widget(text_widget, inner);
+    } else {
+        let tags_display = memory.tags.iter().map(|t| format!("#{}", t)).collect::<Vec<_>>().join(", ");
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(0)])
+            .split(inner);
+        let tags_widget = Paragraph::new(format!("Tags: {}", tags_display))
+            .style(Style::default().fg(Color::Gray));
+        let text_widget = Paragraph::new(memory.text.as_str())
+            .style(Style::default().fg(Color::White))
+            .wrap(Wrap { trim: false });
+        frame.render_widget(tags_widget, chunks[0]);
+        frame.render_widget(text_widget, chunks[1]);
+    }
 }
 
 pub fn handle_key(app: &mut App, key: KeyEvent) {


### PR DESCRIPTION
## Summary

- **Store layer**: Tags stored as `#rust, #til` metadata lines in daily markdown files. `Memory` gains a `tags: Vec<String>` field. `parse_tag_line`, `normalize_tag`, `add_tags`, and `remove_tags` added to `store.rs`. `write_file` and `append` emit tag lines. Full round-trip (write → parse) tested.
- **CLI layer**: `--tag` flag on `add`, `list`, and `search`. New `ikkinchi tags` subcommand (lists all tags with counts). New `ikkinchi tag add/remove` subcommand. `stats` shows distinct tag count; JSON export includes `tags` field.
- **TUI layer**: Tags displayed in list rows (`[#rust, #til]`) and detail view (`Tags: #rust, #til`). Press `t` to open tag picker modal (`Mode::TagFilter`), navigate with `j`/`k`, confirm with `Enter`. Active filter shown with cyan double border and footer hint. `Esc` clears filter.

## Test plan

- [x] `cargo test` — 152 tests, 0 failures
- [x] `ikkinchi add "thought" --tag rust --tag til` → verify tag line written to markdown file
- [x] `ikkinchi list` → tags shown in every row
- [x] `ikkinchi list --tag rust` → only tagged entries returned
- [x] `ikkinchi tags` → tag counts sorted by frequency
- [x] `ikkinchi tag add <id> rust` / `ikkinchi tag remove <id> rust` → tags updated, printed
- [x] `ikkinchi stats` → `Tags: N` line present
- [x] `ikkinchi export --format json` → each entry has `"tags": [...]`
- [x] TUI: press `t`, pick tag, confirm filter active (cyan border); press `Esc` to clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)